### PR TITLE
Add support for box constraints

### DIFF
--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -51,8 +51,10 @@ double exclusive_lasso_penalty(const arma::vec& x, const arma::ivec& groups){
 }
 
 // [[Rcpp::export]]
-arma::vec exclusive_lasso_prox(arma::vec z, const arma::ivec& groups,
-                               double lambda, double thresh=1e-7){
+arma::vec exclusive_lasso_prox(const arma::vec& z,
+                               const arma::ivec& groups,
+                               double lambda,
+                               double thresh=1e-7){
 
     arma::uword p = z.n_elem;
     arma::vec beta(p);

--- a/tests/testthat/test_box_constraints.R
+++ b/tests/testthat/test_box_constraints.R
@@ -1,0 +1,336 @@
+context("Box constraints")
+
+test_that("Error checking for box constraints works", {
+    set.seed(125)
+
+    n <- 200
+    p <- 500
+    groups <- rep(1:10, times=50)
+    beta <- numeric(p);
+    beta[1:10] <- 3
+
+    X <- matrix(rnorm(n * p), ncol=p)
+    y <- X %*% beta + rnorm(n)
+
+    expect_error(exclusive_lasso(X, y, groups, lower.limits = 5, upper.limits = -5))
+
+    expect_error(exclusive_lasso(X, y, groups, lower.limits = rep(5, p - 1)))
+    expect_error(exclusive_lasso(X, y, groups, lower.limits = NA))
+    expect_error(exclusive_lasso(X, y, groups, lower.limits = NaN))
+
+    expect_error(exclusive_lasso(X, y, groups, upper.limits = rep(5, p - 1)))
+    expect_error(exclusive_lasso(X, y, groups, upper.limits = NA))
+    expect_error(exclusive_lasso(X, y, groups, upper.limits = NaN))
+})
+
+test_that("All four gaussian implementations match - non-negative", {
+    set.seed(125)
+
+    n <- 200
+    p <- 500
+    groups <- rep(1:10, times=50)
+    beta <- numeric(p);
+    beta[1:10] <- 3
+
+    X <- matrix(rnorm(n * p), ncol=p)
+    y <- X %*% beta + rnorm(n)
+
+    options(ExclusiveLasso.gaussian_fast_path = TRUE)
+    exfit1 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              lower.limits = rep(0, p), thresh=1e-10, algorithm = "cd")
+    exfit2 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              lower.limits = rep(0, p), thresh=1e-10, algorithm = "pg")
+
+    options(ExclusiveLasso.gaussian_fast_path = FALSE)
+    exfit3 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              lower.limits = rep(0, p), thresh=1e-10, algorithm = "cd")
+    exfit4 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              lower.limits = rep(0, p), thresh=1e-10, algorithm = "pg")
+
+    ## Reset before testing
+    options(ExclusiveLasso.gaussian_fast_path = TRUE)
+
+    expect_equal(coef(exfit1), coef(exfit2))
+    expect_equal(coef(exfit1), coef(exfit3))
+    expect_equal(coef(exfit1), coef(exfit4))
+
+    ## Check all coefficients (but not intercept) are >= 0
+    expect_true(all(coef(exfit1)[-1,] >= 0))
+    expect_true(all(coef(exfit2)[-1,] >= 0))
+    expect_true(all(coef(exfit3)[-1,] >= 0))
+    expect_true(all(coef(exfit4)[-1,] >= 0))
+})
+
+test_that("All four gaussian implementations match - non-positive", {
+    set.seed(521)
+
+    n <- 200
+    p <- 50
+    groups <- rep(1:10, times=5)
+    beta <- numeric(p);
+    beta[1:10] <- 3
+
+    X <- matrix(rnorm(n * p), ncol=p)
+    y <- X %*% beta + rnorm(n)
+
+    options(ExclusiveLasso.gaussian_fast_path = TRUE)
+    exfit1 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              upper.limits = rep(0, p), thresh=1e-10, algorithm = "cd")
+    exfit2 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              upper.limits = rep(0, p), thresh=1e-10, algorithm = "pg")
+
+    options(ExclusiveLasso.gaussian_fast_path = FALSE)
+    exfit3 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              upper.limits = rep(0, p), thresh=1e-10, algorithm = "cd")
+    exfit4 <- exclusive_lasso(X, y, groups, skip_df = TRUE,
+                              upper.limits = rep(0, p), thresh=1e-10, algorithm = "pg")
+
+    ## Reset before testing
+    options(ExclusiveLasso.gaussian_fast_path = TRUE)
+
+    expect_equal(coef(exfit1), coef(exfit2))
+    expect_equal(coef(exfit1), coef(exfit3))
+    expect_equal(coef(exfit1), coef(exfit4), tolerance = 1e-7) # This one is a bit less tight for some reason
+
+    ## Check all coefficients (but not intercept) are <= 0
+    expect_true(all(coef(exfit1)[-1,] <= 0))
+    expect_true(all(coef(exfit2)[-1,] <= 0))
+    expect_true(all(coef(exfit3)[-1,] <= 0))
+    expect_true(all(coef(exfit4)[-1,] <= 0))
+})
+
+test_that("Recovers non-negative Gaussian ridge", {
+    skip("Cannot match glmnet's odd scaling of Gaussian responses")
+
+    ## This should work, but seems not to for some reason...
+    skip_if_not_installed("nnls")
+    library(nnls)
+
+    set.seed(5454)
+
+    n <- 200
+    p <- 20
+    groups <- 1:p
+
+    beta <- rnorm(p, 0, 3)
+    X <- matrix(rnorm(n * p), ncol=p); X[] <- scale(X)
+    y <- X %*% beta + rnorm(n)
+
+    nlambda <- 10
+
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             intercept=FALSE, standardize=FALSE,
+                             lower.limits = rep(0, p),
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    for(i in seq_len(nlambda)){
+        X_aug <- rbind(X, elfit$lambda[i] * diag(1, p, p))
+        y_aug <- c(y, rep(0, p))
+
+        expect_equal(coef(nnls(X_aug, y_aug)),
+                     as.matrix(elfit$coef[,i, drop=FALSE]),
+                     check.attributes=FALSE)
+    }
+})
+
+test_that("Recovers non-negative logistic ridge", {
+    skip_if_not_installed("glmnet") ## For a logistic ridge implementation
+    library(glmnet)
+    set.seed(222)
+
+    n <- 200
+    p <- 20
+    groups <- 1:p
+
+    beta <- rnorm(p, -1, 3)
+    X <- matrix(rnorm(n * p), ncol=p); X[] <- scale(X)
+    y <- round(plogis(X %*% beta + rnorm(n)))
+
+    nlambda <- 10
+
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "binomial", lower.limits = rep(0, p),
+                             intercept=FALSE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "binomial", intercept = FALSE, lower.limits = rep(0, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+
+    ## Now with intercepts
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "binomial", lower.limits = rep(0, p),
+                             intercept=TRUE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "binomial", intercept = TRUE, lower.limits = rep(0, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+})
+
+test_that("Recovers non-negative Poisson ridge", {
+    skip_if_not_installed("glmnet") ## For a poisson ridge implementation
+    library(glmnet)
+    set.seed(7117)
+
+    ## Low-Dimensional
+    n <- 200
+    p <- 20
+    groups <- 1:p
+
+    beta <- rep(0.2, p)
+    X <- matrix(rnorm(n * p), ncol=p); X[] <- scale(X)
+    y <- rpois(n, exp(X %*% beta))
+
+    nlambda <- 10
+
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "poisson", lower.limits = rep(0, p),
+                             intercept=FALSE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "poisson", intercept = FALSE, lower.limits = rep(0, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+
+    ## Now with intercepts
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "poisson", lower.limits = rep(0, p),
+                             intercept=TRUE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "poisson", intercept = TRUE, lower.limits = rep(0, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+})
+
+test_that("Recovers box-constrianed Gaussian ridge", {
+  skip("Cannot match glmnet's odd scaling of Gaussian responses")
+})
+
+test_that("Recovers box-constrianed logistic ridge", {
+    skip_if_not_installed("glmnet") ## For a logistic ridge implementation
+    library(glmnet)
+    set.seed(555)
+
+    n <- 200
+    p <- 20
+    groups <- 1:p
+
+    beta <- rnorm(p, 0, 3)
+    X <- matrix(rnorm(n * p), ncol=p); X[] <- scale(X)
+    y <- round(plogis(X %*% beta + rnorm(n)))
+
+    nlambda <- 10
+
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "binomial",
+                             lower.limits = rep(-3, p), upper.limits = rep(3, p),
+                             intercept=FALSE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "binomial", intercept = FALSE,
+                    lower.limits = rep(-3, p), upper.limits = rep(3, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+
+    ## Now with intercepts
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "binomial",
+                             lower.limits = rep(-3, p), upper.limits = rep(3, p),
+                             intercept=TRUE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "binomial", intercept = TRUE,
+                    lower.limits = rep(-3, p), upper.limits = rep(3, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+})
+
+test_that("Recovers box-constrianed Poisson ridge", {
+    skip_if_not_installed("glmnet") ## For a poisson ridge implementation
+    library(glmnet)
+    set.seed(1771)
+
+    ## Low-Dimensional
+    n <- 200
+    p <- 20
+    groups <- 1:p
+
+    beta <- rep(0.2, p)
+    X <- matrix(rnorm(n * p), ncol=p); X[] <- scale(X)
+    y <- rpois(n, exp(X %*% beta))
+
+    nlambda <- 10
+
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "poisson",
+                             lower.limits = rep(-0.1, p), upper.limits = rep(0.1, p),
+                             intercept=FALSE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "poisson", intercept = FALSE,
+                    lower.limits = rep(-0.1, p), upper.limits = rep(0.1, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+
+    ## Now with intercepts
+    elfit <- exclusive_lasso(X, y, groups, nlambda=nlambda,
+                             family = "poisson",
+                             lower.limits = rep(-0.1, p), upper.limits = rep(0.1, p),
+                             intercept=TRUE, standardize=FALSE,
+                             thresh=1e-14, thresh_prox=1e-14, skip_df = TRUE)
+
+    glfit <- glmnet(X, y, family = "poisson", intercept = TRUE,
+                    lower.limits = rep(-0.1, p), upper.limits = rep(0.1, p),
+                    lambda = rev(elfit$lambda), standardize = FALSE,
+                    alpha = 0, thresh = 1e-20)
+
+    for(i in seq_len(nlambda)){
+        ## Glmnet returns coefficients 'reversed' compared to how we do it
+        expect_equal(coef(elfit)[, i], coef(glfit)[,nlambda - i + 1],
+                     check.attributes = FALSE)
+    }
+})

--- a/tests/testthat/test_gaussian.R
+++ b/tests/testthat/test_gaussian.R
@@ -1,4 +1,11 @@
 context("Gaussian response exclusive lasso works")
+
+prox <- function(x, ...) {
+    as.vector(ExclusiveLasso:::exclusive_lasso_prox(x, ...,
+                                                    upper_bound = rep(Inf, length(x)),
+                                                    lower_bound = rep(-Inf, length(x))))
+}
+
 ## This focuses on the specialized gaussian fast path
 
 test_that("Input validation works", {
@@ -207,8 +214,7 @@ test_that("Returns prox for orthogonal case", {
 
     elfit <- exclusive_lasso(X, y, groups, lambda=lambda,
                              standardize=FALSE, intercept=FALSE, skip_df = TRUE)
-    prox_coefs <- ExclusiveLasso:::exclusive_lasso_prox(crossprod(X, y),
-                                                        groups, lambda * n)
+    prox_coefs <- prox(crossprod(X, y), groups, lambda * n)
 
     expect_equal(as.matrix(elfit$coef), prox_coefs, check.attributes=FALSE)
 })

--- a/tests/testthat/test_prox.R
+++ b/tests/testthat/test_prox.R
@@ -1,6 +1,10 @@
 context("Proximal operator works")
 
-prox <- function(...) as.vector(ExclusiveLasso:::exclusive_lasso_prox(...))
+prox <- function(x, ...) {
+    as.vector(ExclusiveLasso:::exclusive_lasso_prox(x, ...,
+                                                    upper_bound = rep(Inf, length(x)),
+                                                    lower_bound = rep(-Inf, length(x))))
+}
 
 norm_1 <- function(x) sum(abs(x))
 

--- a/vignettes/ExclusiveLasso.Rmd
+++ b/vignettes/ExclusiveLasso.Rmd
@@ -255,6 +255,9 @@ weight matrix $\bW$ and an intercept term $\alpha$, the combined algorithm becom
     - $\beta^{(k)} = x$
     - $\alpha^{(k)} = \left\langle \text{diag}(\bW)/n, \by - \bo - \bX\beta\right\rangle$
     - $k := k + 1$.
+    
+If we wish to include box constraints of the form $l_i \leq \beta_i \leq u_i$, we
+can simply directly impose these after each soft-thresholding step.
 
 ### Coordinate Descent
 
@@ -288,7 +291,7 @@ Using similar algebra as before:
 \[\begin{align*}
 &\argmin_{\beta_i} \frac{1}{2n} \|\br - \bx_i\beta_i\|_2^2 + \frac{\lambda}{2}\left(|\beta_i| + \|\beta_{g,-i}\|_1\right)^2 \\
 \implies & \argmin_{\beta_i} \frac{1}{2} \|\br - \bx_i\beta_i\|_2^2 + \frac{n\lambda}{2}\left(|\beta_i| + \|\beta_{g,-i}\|_1\right)^2 \\
-\implies & \argmin_{\beta_i} \frac{\|\br\|_2^2 - 2\br^T\bx_i\beta_i + \|\bx_i\|_2^2\beta_i^2 + n\lambda(\beta_i^2 + 2|\beta_i| * \|\beta_{g,-i}\|_1 + \|\beta_{g,-i}\|_1^2}{2} \\
+\implies & \argmin_{\beta_i} \frac{\|\br\|_2^2 - 2\br^T\bx_i\beta_i + \|\bx_i\|_2^2\beta_i^2 + n\lambda(\beta_i^2 + 2|\beta_i| * \|\beta_{g,-i}\|_1 + \|\beta_{g,-i}\|_1^2)}{2} \\
 \implies & \argmin_{\beta_i} \frac{\beta_i^2 (\|\bx_i\|_2^2 + n\lambda) - 2\br^T\bx_i\beta_i + 2n\lambda |\beta_i| * \|\beta_{g, -i}\|_1}{2} \\
 \implies & \argmin_{\beta_i} n\lambda\|\beta_{g,-i}\|_1 * |\beta_i| +\frac{1}{2}\left(\beta_i^2 (\|\bx_i\|_2^2 + n\lambda) - 2\br^T\bx_i\beta_i \right) \\
 \implies & \argmin_{\beta_i} \frac{n\lambda\|\beta_{g,-i}\|_1}{\|\bx_i\|_2^2 + n\lambda} * |\beta_i| +\frac{1}{2(\|\bx_i\|_2^2 + n\lambda)}\left(\beta_i^2 (\|\bx_i\|_2^2 + n\lambda) - 2\br^T\bx_i\beta_i \right) \\
@@ -342,6 +345,9 @@ algorithm becomes:
         - Update working residual: $\br: \br + \alpha 1_n$
         - Update intercept: $\alpha := \langle \br, \text{diag}(\bW)/n \rangle$
         - Update working residual: $\br := \br - \alpha 1_{n}$
+        
+If we wish to include box constraints of the form $l_i \leq \beta_i \leq u_i$, we
+can simply directly impose these after each soft-thresholding step.
 
 ## Generalized Linear Models with the Exclusive Lasso Penalty
 
@@ -438,6 +444,8 @@ The final algorithm is then:
 where $\ell$ is the smooth part of the objective function (*i.e.*, the negative 
 log-likelihood), and the proximal operator is evaluated using the coordinate-descent
 scheme described above.
+
+Box constraints can be imposed in the proximal operator, as described above.
 
 ### Coordinate Descent Algorithm
 
@@ -545,6 +553,9 @@ scheme derived above, yielding our proximal Newton algorithm:
         - $\widetilde{\bw} = g'(\eta)$
         - $\bz = \widetilde{\bW}^{-1}(y - g(\eta)) + \eta$
         - $\br = \bz - \eta$
+
+If we wish to include box constraints of the form $l_i \leq \beta_i \leq u_i$, we
+can simply directly impose these after each soft-thresholding step.
 
 The inverse link $g$ and weighting $g'$ functions are easily calculated, by simple 
 extensions of calculations performed above:


### PR DESCRIPTION
Add box constraints (upper and lower bounds). We do not enforce an all zero solution at any point so we don't require lower bounds to be negative or upper bounds to be positive (unlike `glmnet`).