### PR TITLE
Improve C++ Hygiene

### DIFF
--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -477,7 +477,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
 
         do {
             beta_old = beta_working;
-            for(int j=0; j < p; j++){
+            for(arma::uword j=0; j < p; j++){
                 double beta = beta_working(j);
 
                 if((!full_loop) && (beta == 0)){
@@ -736,7 +736,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
 
             do { // Inner CD Loop
                 beta_cd_old = beta_working;
-                for(int j=0; j < p; j++){
+                for(arma::uword j=0; j < p; j++){
                     double beta = beta_working(j);
 
                     if((!full_loop) && (beta == 0)){

--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -45,10 +45,10 @@ double norm_sq(const arma::vec& x, const arma::vec& w){
 }
 
 // [[Rcpp::export]]
-double exclusive_lasso_penalty(const arma::vec& x, const arma::uvec& groups){
+double exclusive_lasso_penalty(const arma::vec& x, const arma::ivec& groups){
     double ans = 0;
 
-    for(arma::uword g = arma::min(groups); g <= arma::max(groups); g++){
+    for(arma::sword g = arma::min(groups); g <= arma::max(groups); g++){
         ans += pow(arma::norm(x(arma::find(g == groups)), 1), 2);
     }
 
@@ -57,7 +57,7 @@ double exclusive_lasso_penalty(const arma::vec& x, const arma::uvec& groups){
 
 // [[Rcpp::export]]
 arma::vec exclusive_lasso_prox(const arma::vec& z,
-                               const arma::uvec& groups,
+                               const arma::ivec& groups,
                                double lambda,
                                const arma::vec& lower_bound,
                                const arma::vec& upper_bound,
@@ -70,7 +70,7 @@ arma::vec exclusive_lasso_prox(const arma::vec& z,
 
     // TODO -- parallelize?
     // Loop over groups
-    for(arma::uword g = arma::min(groups); g <= arma::max(groups); g++){
+    for(arma::sword g = arma::min(groups); g <= arma::max(groups); g++){
         // Identify elements in group
         arma::uvec g_ix = arma::find(g == groups);
         int g_n_elem = g_ix.n_elem;
@@ -108,7 +108,7 @@ arma::vec exclusive_lasso_prox(const arma::vec& z,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
                                        const arma::vec& y,
-                                       const arma::uvec& groups,
+                                       const arma::ivec& groups,
                                        const arma::vec& lambda,
                                        const arma::vec& w,
                                        const arma::vec& o,
@@ -215,7 +215,7 @@ Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
                                   const arma::vec& y,
-                                  const arma::uvec& groups,
+                                  const arma::ivec& groups,
                                   const arma::vec& lambda,
                                   const arma::vec& w,
                                   const arma::vec& o,
@@ -417,7 +417,7 @@ Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                                        const arma::vec& y,
-                                       const arma::uvec& groups,
+                                       const arma::ivec& groups,
                                        const arma::vec& lambda,
                                        const arma::vec& w,
                                        const arma::vec& o,
@@ -487,7 +487,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                 const arma::vec xj = X.col(j);
                 r += xj * beta;
 
-                arma::uword g = groups(j);
+                arma::sword g = groups(j);
                 g_norms(g) -= std::abs(beta);
 
                 double z = arma::dot(r % w, xj);
@@ -579,7 +579,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
                                   const arma::vec& y,
-                                  const arma::uvec& groups,
+                                  const arma::ivec& groups,
                                   const arma::vec& lambda,
                                   const arma::vec& w,
                                   const arma::vec& o,
@@ -746,7 +746,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
                     const arma::vec xj = X.col(j);
                     r += xj * beta;
 
-                    arma::uword g = groups(j);
+                    arma::sword g = groups(j);
                     g_norms(g) -= std::abs(beta);
 
                     const double zeta = arma::dot(r % combined_weights, xj);
@@ -908,7 +908,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
 // [[Rcpp::export]]
 arma::mat calculate_exclusive_lasso_df(const arma::mat& X,
                                        const arma::vec& lambda_vec,
-                                       const arma::uvec& groups,
+                                       const arma::ivec& groups,
                                        const arma::sp_mat& coefs){
 
     arma::vec res(lambda_vec.n_elem, arma::fill::zeros);
@@ -927,7 +927,7 @@ arma::mat calculate_exclusive_lasso_df(const arma::mat& X,
         arma::mat M(X.n_cols, X.n_cols, arma::fill::zeros);
 
         // Loop over groups to build M matrix
-        for(arma::uword g = arma::min(groups); g <= arma::max(groups); g++){
+        for(arma::sword g = arma::min(groups); g <= arma::max(groups); g++){
             // Identify elements in group
             arma::uvec g_ix = arma::find(g == groups);
             arma::vec  s_g  = arma::sign(coef(g_ix));

--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -125,8 +125,8 @@ Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
     arma::vec Xty = X.t() * (w % (y - o)/n);
     double L = arma::max(arma::eig_sym(XtX));
 
-    uint beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
-    uint beta_nnz = 0;
+    arma::uword beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
+    arma::uword beta_nnz = 0;
     arma::umat Beta_storage_ind(2, beta_nnz_approx);
     arma::vec  Beta_storage_vec(beta_nnz_approx);
 
@@ -134,7 +134,7 @@ Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
     arma::vec Alpha(n_lambda, arma::fill::zeros);
 
     // Number of prox gradient iterations -- used to check for interrupts
-    uint k = 0;
+    arma::uword k = 0;
 
     arma::vec beta(p, arma::fill::zeros);
     double alpha = 0;
@@ -179,7 +179,7 @@ Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
         }
 
         // Load sparse matrix storage
-        for(uint j=0; j < p; j++){
+        for(arma::uword j=0; j < p; j++){
             if(beta(j) != 0){
                 // We want to have a coefficient matrix
                 // where rows are features and columns are values of lambda
@@ -242,8 +242,8 @@ Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
     arma::uword p = X1.n_cols;
     arma::uword n_lambda = lambda.n_elem;
 
-    uint beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
-    uint beta_nnz = 0;
+    arma::uword beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
+    arma::uword beta_nnz = 0;
     arma::umat Beta_storage_ind(2, beta_nnz_approx);
     arma::vec  Beta_storage_vec(beta_nnz_approx);
 
@@ -254,7 +254,7 @@ Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
     arma::vec Alpha(n_lambda, arma::fill::zeros);
 
     // Number of prox gradient iterations -- used to check for interrupts
-    uint k = 0;
+    arma::uword k = 0;
 
     arma::vec beta(p, arma::fill::zeros);
     arma::vec beta_old(p);
@@ -377,7 +377,7 @@ Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
         }
 
         // Load sparse matrix storage
-        for(uint j=0; j < p; j++){
+        for(arma::uword j=0; j < p; j++){
             if(beta(j) != 0){
                 if(intercept && (j == p - 1)){
                     // Handle intercept specially
@@ -436,7 +436,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
     double alpha = 0;
 
     arma::vec u(p);
-    for(uint i=0; i<p; i++){
+    for(arma::uword i=0; i<p; i++){
         u(i) = arma::sum(arma::square(X.col(i)) % w);
     }
 
@@ -448,8 +448,8 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
     // so this is tight, but should be safe generally.
     arma::vec g_norms(arma::max(groups) + 1, arma::fill::zeros);
 
-    uint beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
-    uint beta_nnz = 0;
+    arma::uword beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
+    arma::uword beta_nnz = 0;
     arma::umat Beta_storage_ind(2, beta_nnz_approx);
     arma::vec  Beta_storage_vec(beta_nnz_approx);
 
@@ -458,15 +458,15 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
     arma::vec Alpha(n_lambda, arma::fill::zeros); // Storage for intercepts
 
     // Number of cd iterations -- used to check for interrupts
-    uint k = 0;
+    arma::uword k = 0;
 
     // For first iteration we want to loop over all variables since
     // we haven't identified the active set yet
     bool full_loop = true;
-    uint full_loop_count = 0; // Number of full loops completed
-                              // We require at least EXLASSO_FULL_LOOP_MIN
-                              // full loops before moving to the next value
-                              // of lambda to ensure convergence
+    arma::uword full_loop_count = 0; // Number of full loops completed
+                                     // We require at least EXLASSO_FULL_LOOP_MIN
+                                     // full loops before moving to the next value
+                                     // of lambda to ensure convergence
 
     // Iterate from highest to smallest lambda
     // to take advantage of
@@ -486,7 +486,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                 const arma::vec xj = X.col(j);
                 r += xj * beta;
 
-                uint g = groups(j);
+                arma::uword g = groups(j);
                 g_norms(g) -= fabs(beta);
 
                 double z = arma::dot(r % w, xj);
@@ -543,7 +543,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
         }
 
         // Load sparse matrix storage
-        for(uint j=0; j < p; j++){
+        for(arma::uword j=0; j < p; j++){
             if(beta_working(j) != 0){
                 // We want to have a coefficient matrix
                 // where rows are features and columns are values of lambda
@@ -688,8 +688,8 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
     // so this is tight, but should be safe generally.
     arma::vec g_norms(arma::max(groups) + 1, arma::fill::zeros);
 
-    uint beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
-    uint beta_nnz = 0;
+    arma::uword beta_nnz_approx = EXLASSO_PREALLOCATION_FACTOR * p;
+    arma::uword beta_nnz = 0;
     arma::umat Beta_storage_ind(2, beta_nnz_approx);
     arma::vec  Beta_storage_vec(beta_nnz_approx);
 
@@ -700,15 +700,15 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
     arma::vec Alpha(n_lambda, arma::fill::zeros); // Storage for intercepts
 
     // Number of cd iterations -- used to check for interrupts
-    uint k = 0;
+    arma::uword k = 0;
 
     // Number of SQA iterations
-    uint K = 0;
+    arma::uword K = 0;
 
     // For first iteration we want to loop over all variables since
     // we haven't identified the active set yet
     bool full_loop = true;
-    uint full_loop_count = 0; // Number of full loops completed
+    arma::uword full_loop_count = 0; // Number of full loops completed
 
     // We require at least EXLASSO_FULL_LOOP_MIN
     // full loops before moving to the next value
@@ -727,7 +727,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
             beta_sqa_old = beta_working; // Save these for PN back-tracking
             alpha_old    = alpha;
             arma::vec u(p);
-            for(uint i=0; i<p; i++){
+            for(arma::uword i=0; i<p; i++){
                 u(i) = arma::sum(arma::square(X.col(i)) % combined_weights);
             }
 
@@ -745,7 +745,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
                     const arma::vec xj = X.col(j);
                     r += xj * beta;
 
-                    uint g = groups(j);
+                    arma::uword g = groups(j);
                     g_norms(g) -= fabs(beta);
 
                     const double zeta = arma::dot(r % combined_weights, xj);
@@ -869,7 +869,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
         }
 
         // Load sparse matrix storage
-        for(uint j=0; j < p; j++){
+        for(arma::uword j=0; j < p; j++){
             if(beta_working(j) != 0){
                 // We want to have a coefficient matrix
                 // where rows are features and columns are values of lambda

--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -44,7 +44,7 @@ double norm_sq(const arma::vec& x, const arma::vec& w){
 }
 
 // [[Rcpp::export]]
-double exclusive_lasso_penalty(const arma::vec& x, const arma::ivec& groups){
+double exclusive_lasso_penalty(const arma::vec& x, const arma::uvec& groups){
     double ans = 0;
 
     for(arma::uword g = arma::min(groups); g <= arma::max(groups); g++){
@@ -56,7 +56,7 @@ double exclusive_lasso_penalty(const arma::vec& x, const arma::ivec& groups){
 
 // [[Rcpp::export]]
 arma::vec exclusive_lasso_prox(const arma::vec& z,
-                               const arma::ivec& groups,
+                               const arma::uvec& groups,
                                double lambda,
                                const arma::vec& lower_bound,
                                const arma::vec& upper_bound,
@@ -107,7 +107,7 @@ arma::vec exclusive_lasso_prox(const arma::vec& z,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
                                        const arma::vec& y,
-                                       const arma::ivec& groups,
+                                       const arma::uvec& groups,
                                        const arma::vec& lambda,
                                        const arma::vec& w,
                                        const arma::vec& o,
@@ -214,7 +214,7 @@ Rcpp::List exclusive_lasso_gaussian_pg(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
                                   const arma::vec& y,
-                                  const arma::ivec& groups,
+                                  const arma::uvec& groups,
                                   const arma::vec& lambda,
                                   const arma::vec& w,
                                   const arma::vec& o,
@@ -416,7 +416,7 @@ Rcpp::List exclusive_lasso_glm_pg(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                                        const arma::vec& y,
-                                       const arma::ivec& groups,
+                                       const arma::uvec& groups,
                                        const arma::vec& lambda,
                                        const arma::vec& w,
                                        const arma::vec& o,
@@ -578,7 +578,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
 // [[Rcpp::export]]
 Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
                                   const arma::vec& y,
-                                  const arma::ivec& groups,
+                                  const arma::uvec& groups,
                                   const arma::vec& lambda,
                                   const arma::vec& w,
                                   const arma::vec& o,
@@ -907,7 +907,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
 // [[Rcpp::export]]
 arma::mat calculate_exclusive_lasso_df(const arma::mat& X,
                                        const arma::vec& lambda_vec,
-                                       const arma::ivec& groups,
+                                       const arma::uvec& groups,
                                        const arma::sp_mat& coefs){
 
     arma::vec res(lambda_vec.n_elem, arma::fill::zeros);

--- a/src/ExclusiveLasso.cpp
+++ b/src/ExclusiveLasso.cpp
@@ -1,5 +1,6 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 #include <limits>
+#include <cmath>
 
 #define EXLASSO_CHECK_USER_INTERRUPT_RATE 50
 #define EXLASSO_CHECK_USER_INTERRUPT_RATE_GLM 10
@@ -83,7 +84,7 @@ arma::vec exclusive_lasso_prox(const arma::vec& z,
             int k = 0;
             beta_g_old = beta_g;
             for(int i=0; i<g_n_elem; i++){
-                double thresh_level = arma::norm(beta_g, 1) - fabs(beta_g(i));
+                double thresh_level = arma::norm(beta_g, 1) - std::abs(beta_g(i));
                 beta_g(i) = 1/(lambda + 1) * soft_thresh(z_g(i), lambda * thresh_level);
 
                 // Impose box constraints
@@ -487,7 +488,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                 r += xj * beta;
 
                 arma::uword g = groups(j);
-                g_norms(g) -= fabs(beta);
+                g_norms(g) -= std::abs(beta);
 
                 double z = arma::dot(r % w, xj);
                 double lambda_til = nl * g_norms(g);
@@ -501,7 +502,7 @@ Rcpp::List exclusive_lasso_gaussian_cd(const arma::mat& X,
                 }
 
                 r -= xj * beta;
-                g_norms(g) += fabs(beta);
+                g_norms(g) += std::abs(beta);
 
                 beta_working(j) = beta;
             }
@@ -746,7 +747,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
                     r += xj * beta;
 
                     arma::uword g = groups(j);
-                    g_norms(g) -= fabs(beta);
+                    g_norms(g) -= std::abs(beta);
 
                     const double zeta = arma::dot(r % combined_weights, xj);
                     const double lambda_til = nl * g_norms(g);
@@ -761,7 +762,7 @@ Rcpp::List exclusive_lasso_glm_cd(const arma::mat& X,
 
                     r -= xj * beta;
 
-                    g_norms(g) += fabs(beta);
+                    g_norms(g) += std::abs(beta);
                     beta_working(j) = beta;
                 }
 

--- a/tests/testthat/test_prox.R
+++ b/tests/testthat/test_prox.R
@@ -134,3 +134,14 @@ test_that("prox never is fully sparse for any group", {
     expect_false(all(prox_x == 0))
     expect_true(all(unique(g) %in% g[prox_x != 0]))
 })
+
+test_that("negative group IDs are supported", {
+    set.seed(900)
+
+    n <- 200L
+    G <- 50L
+    x <- rnorm(n)
+    g <- rep.int(seq.int(0L, G - 1), n / G)
+
+    expect_equal(prox(x, g, 3), prox(x, -g, 3))
+})


### PR DESCRIPTION
Minor clean-ups to C++ hygiene: 

- Use `arma::uword` instead of non-standard `uint`
- Use `arma::sword` for elements of `arma::ivec` (group membership indicators)
- Use `std::abs` instead of C's `fabs`